### PR TITLE
Set close-on-exec flag on listening sockets

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -2787,7 +2787,7 @@ evhtp_bind_sockaddr(evhtp_t * htp, struct sockaddr * sa, size_t sin_len, int bac
 #endif
 
     htp->server = evconnlistener_new_bind(htp->evbase, _evhtp_accept_cb, (void *)htp,
-                                          LEV_OPT_THREADSAFE | LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE,
+                                          LEV_OPT_THREADSAFE | LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_EXEC,
                                           backlog, sa, sin_len);
     if (!htp->server) {
         return -1;


### PR DESCRIPTION
This allows a program to:

* Start the HTTP listener on a port
* Spawn a subprocess.
* Stop the HTTP listener
* Start the HTTP listener on the same port

Without the close-on-exec flag the last step would fail with an address in use error